### PR TITLE
finished Data Persistence Support for Private Conversations

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -122,7 +122,7 @@ public class ConversationServlet extends HttpServlet {
     }
 
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now());
+        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now(), false);
 
     conversationStore.addConversation(conversation);
     adminStore.addConversation(conversation);

--- a/src/main/java/codeu/controller/TestDataServlet.java
+++ b/src/main/java/codeu/controller/TestDataServlet.java
@@ -23,6 +23,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+// import org.apache.commons.fileupload.servlet.ServletFileUpload;
+
 
 /** Servlet class responsible for loading test data. */
 public class TestDataServlet extends HttpServlet {

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -26,6 +26,7 @@ public class Conversation {
   public final UUID owner;
   public final Instant creation;
   public final String title;
+  private final boolean isPrivate;
 
   /**
    * Constructs a new Conversation.
@@ -35,11 +36,12 @@ public class Conversation {
    * @param title the title of this Conversation
    * @param creation the creation time of this Conversation
    */
-  public Conversation(UUID id, UUID owner, String title, Instant creation) {
+  public Conversation(UUID id, UUID owner, String title, Instant creation, boolean isPrivate) {
     this.id = id;
     this.owner = owner;
     this.creation = creation;
     this.title = title;
+    this.isPrivate = isPrivate;
   }
 
   /** Returns the ID of this Conversation. */
@@ -61,4 +63,10 @@ public class Conversation {
   public Instant getCreationTime() {
     return creation;
   }
+
+  /** Returns the private/public status of this Conversation. */
+  public boolean isPrivate() {
+    return isPrivate;
+  }
 }
+

--- a/src/main/java/codeu/model/data/UserConversationMap.java
+++ b/src/main/java/codeu/model/data/UserConversationMap.java
@@ -1,0 +1,49 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.model.data;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+/** Class representing a map from username to conversation id. */
+public class UserConversationMap {
+  private final UUID userID;
+  private final UUID conversationID;
+
+  /**
+   * Constructs a new User.
+   *
+   * @param userID the ID of a User
+   * @param conversationID the ID of a Conversation
+   */
+  public UserConversationMap(UUID userID, UUID conversationID) {
+    this.userID = userID;
+    this.conversationID = conversationID;
+  }
+
+  /** Returns the ID of this User. */
+  public UUID getUserID() {
+    return userID;
+  }
+
+  public UUID getConversationID() {
+    return conversationID;
+  }
+
+}

--- a/src/main/java/codeu/model/store/basic/ConversationMappingStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationMappingStore.java
@@ -1,0 +1,89 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codeu.model.store.basic;
+
+import codeu.model.data.User;
+import codeu.model.data.UserConversationMap;
+import codeu.model.store.persistence.PersistentStorageAgent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Store class that uses in-memory data structures to hold values and automatically loads from and
+ * saves to PersistentStorageAgent. It's a singleton so all servlet classes can access the same
+ * instance.
+ */
+public class ConversationMappingStore {
+
+  /** Singleton instance of ConversationMappingStore. */
+  private static ConversationMappingStore instance;
+
+  /**
+   * Returns the singleton instance of ConversationMappingStore that should be shared between all servlet classes.
+   * Do not call this function from a test; use getTestInstance() instead.
+   */
+  public static ConversationMappingStore getInstance() {
+    if (instance == null) {
+      instance = new ConversationMappingStore(PersistentStorageAgent.getInstance());
+    }
+    return instance;
+  }
+
+  /**
+   * Instance getter function used for testing. Supply a mock for PersistentStorageAgent.
+   *
+   * @param persistentStorageAgent a mock used for testing
+   */
+  public static ConversationMappingStore getTestInstance(PersistentStorageAgent persistentStorageAgent) {
+    return new ConversationMappingStore(persistentStorageAgent);
+  }
+
+  /**
+   * The PersistentStorageAgent responsible for loading UserConversationMaps from and saving UserConversationMaps to Datastore.
+   */
+  private PersistentStorageAgent persistentStorageAgent;
+
+  /** The in-memory list of ConversationMapping. */
+  private List<UserConversationMap> mappings;
+
+  /** This class is a singleton, so its constructor is private. Call getInstance() instead. */
+  private ConversationMappingStore(PersistentStorageAgent persistentStorageAgent) {
+    this.persistentStorageAgent = persistentStorageAgent;
+    mappings = new ArrayList<>();
+  }
+
+  public void addMapping(UserConversationMap mapping) {
+  	mappings.add(mapping);
+    persistentStorageAgent.writeThrough(mapping);
+  }
+
+  public List<UUID> getConversationsWithUserID(UUID userID) {
+
+    List<UUID> conversationIDs = new ArrayList<>();
+
+  	for (UserConversationMap mapping : mappings) {
+  		if (mapping.getUserID().equals(userID)) {
+  			conversationIDs.add(mapping.getConversationID());
+  		}
+  	}
+  	return conversationIDs;
+  }
+
+  public void setMappings(List<UserConversationMap> mappings) {
+    this.mappings = mappings;
+  }
+
+}

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -59,11 +59,18 @@ public class ConversationStore {
   /** The in-memory list of Conversations. */
   private List<Conversation> conversations;
 
+  /** The in-memory list of private Conversations. */
+  private List<Conversation> privateConversations;
+
+
   /** This class is a singleton, so its constructor is private. Call getInstance() instead. */
   private ConversationStore(PersistentStorageAgent persistentStorageAgent) {
     this.persistentStorageAgent = persistentStorageAgent;
     conversations = new ArrayList<>();
+    privateConversations = new ArrayList<>();
   }
+
+
 
   /**
    * Load a set of randomly-generated Conversation objects.
@@ -88,6 +95,10 @@ public class ConversationStore {
   }
 
 
+  /** Access the current set of private conversations known to the application. */
+  public List<Conversation> getAllPrivateConversations() {
+    return privateConversations;
+  }
 
 
 
@@ -97,6 +108,14 @@ public class ConversationStore {
     persistentStorageAgent.writeThrough(conversation);
   }
 
+
+  /** Add a new conversation to the current set of conversations known to the application. */
+  public void addPrivateConversation(Conversation privateConversation) {
+    privateConversations.add(privateConversation);
+    persistentStorageAgent.writeThrough(privateConversation);
+  }
+
+
   /** Check whether a Conversation title is already known to the application. */
   public boolean isTitleTaken(String title) {
     // This approach will be pretty slow if we have many Conversations.
@@ -105,8 +124,14 @@ public class ConversationStore {
         return true;
       }
     }
+    for (Conversation privateConversation : privateConversations) {
+      if (privateConversation.getTitle().equals(title)) {
+        return true;
+      }
+    }
     return false;
   }
+
 
   /** Find and return the Conversation with the given title. */
   public Conversation getConversationWithTitle(String title) {
@@ -115,14 +140,25 @@ public class ConversationStore {
         return conversation;
       }
     }
+    for (Conversation privateConversation : privateConversations) {
+      if (privateConversation.getTitle().equals(title)) {
+        return privateConversation;
+      }
+    }
     return null;
   }
+
 
   /** Find and return the Conversation with the given Id. */
   public Conversation getConversationWithId(UUID conversationId) {
     for (Conversation conversation : conversations) {
       if (conversation.getId().equals(conversationId)) {
         return conversation;
+      }
+    }
+    for (Conversation privateConversation : privateConversations) {
+      if (privateConversation.getId().equals(conversationId)) {
+        return privateConversation;
       }
     }
     return null;
@@ -144,6 +180,11 @@ public class ConversationStore {
   /** Sets the List of Conversations stored by this ConversationStore. */
   public void setConversations(List<Conversation> conversations) {
     this.conversations = conversations;
+  }
+
+  /** Sets the List of private Conversations stored by this ConversationStore. */
+  public void setPrivateConversations(List<Conversation> privateConversations) {
+    this.privateConversations = privateConversations;
   }
 
   public int getTotal(){

--- a/src/main/java/codeu/model/store/basic/DefaultDataStore.java
+++ b/src/main/java/codeu/model/store/basic/DefaultDataStore.java
@@ -17,6 +17,7 @@ package codeu.model.store.basic;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.UserConversationMap;
 import codeu.model.store.persistence.PersistentStorageAgent;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -111,7 +112,7 @@ public class DefaultDataStore {
       User user = getRandomElement(users);
       String title = "Conversation_" + i;
       Conversation conversation =
-          new Conversation(UUID.randomUUID(), user.getId(), title, Instant.now());
+          new Conversation(UUID.randomUUID(), user.getId(), title, Instant.now(), false);
       PersistentStorageAgent.getInstance().writeThrough(conversation);
       conversations.add(conversation);
     }

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -17,8 +17,10 @@ package codeu.model.store.persistence;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.UserConversationMap;
 import codeu.model.store.persistence.PersistentDataStore;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * This class is the interface between the application and PersistentDataStore, which handles
@@ -79,6 +81,14 @@ public class PersistentStorageAgent {
     return persistentDataStore.loadConversations();
   }
 
+  public List<Conversation> loadPrivateConversations(String username) throws PersistentDataStoreException {
+    return persistentDataStore.loadPrivateConversations(username);
+  }
+
+  public List<Conversation> loadPrivateConversations(UUID userID) throws PersistentDataStoreException {
+    return persistentDataStore.loadPrivateConversations(userID);
+  }
+
   /**
    * Retrieve all Message objects from the Datastore service. The returned list may be empty.
    *
@@ -99,13 +109,18 @@ public class PersistentStorageAgent {
     persistentDataStore.writeThrough(user);
   }
 
-  /** Write a Message object to the Datastore service. */
+  /** Write a Conversation object to the Datastore service. */
   public void writeThrough(Conversation conversation) {
     persistentDataStore.writeThrough(conversation);
   }
 
-  /** Write a Conversation object to the Datastore service. */
+  /** Write a Message object to the Datastore service. */
   public void writeThrough(Message message) {
     persistentDataStore.writeThrough(message);
+  }
+
+  /** Write a UserConversationMap object to the Datastore service. */
+  public void writeThrough(UserConversationMap userConversation) {
+    persistentDataStore.writeThrough(userConversation);
   }
 }

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -17,6 +17,7 @@ package codeu.controller;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.UserConversationMap;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
@@ -76,7 +77,7 @@ public class ChatServletTest {
 
     UUID fakeConversationId = UUID.randomUUID();
     Conversation fakeConversation =
-        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now(), false);
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
         .thenReturn(fakeConversation);
 

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -68,7 +68,7 @@ public class ConversationServletTest {
   public void testDoGet() throws IOException, ServletException {
     List<Conversation> fakeConversationList = new ArrayList<>();
     fakeConversationList.add(
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now()));
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false));
     Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
 
     conversationServlet.doGet(mockRequest, mockResponse);

--- a/src/test/java/codeu/model/data/UserConversationMapTest.java
+++ b/src/test/java/codeu/model/data/UserConversationMapTest.java
@@ -14,27 +14,20 @@
 
 package codeu.model.data;
 
-import java.time.Instant;
 import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ConversationTest {
+public class UserConversationMapTest {
 
   @Test
   public void testCreate() {
-    UUID id = UUID.randomUUID();
-    UUID owner = UUID.randomUUID();
-    String title = "Test_Title";
-    Instant creation = Instant.now();
-    boolean isPrivate = true;
-
-    Conversation conversation = new Conversation(id, owner, title, creation, isPrivate);
-
-    Assert.assertEquals(id, conversation.getId());
-    Assert.assertEquals(owner, conversation.getOwnerId());
-    Assert.assertEquals(title, conversation.getTitle());
-    Assert.assertEquals(creation, conversation.getCreationTime());
-    Assert.assertEquals(isPrivate, conversation.isPrivate());
+    UUID userID = UUID.randomUUID();
+    UUID conversationID = UUID.randomUUID();
+    
+    UserConversationMap mapping = new UserConversationMap(userID, conversationID);
+    
+    Assert.assertEquals(userID, mapping.getUserID());
+    Assert.assertEquals(conversationID, mapping.getConversationID());
   }
 }

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -18,7 +18,7 @@ public class ConversationStoreTest {
 
   private final Conversation CONVERSATION_ONE =
       new Conversation(
-          UUID.randomUUID(), UUID.randomUUID(), "conversation_one", Instant.ofEpochMilli(1000));
+          UUID.randomUUID(), UUID.randomUUID(), "conversation_one", Instant.ofEpochMilli(1000), false);
 
   @Before
   public void setup() {
@@ -62,7 +62,7 @@ public class ConversationStoreTest {
   @Test
   public void testAddConversation() {
     Conversation inputConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);
 
     conversationStore.addConversation(inputConversation);
     Conversation resultConversation =
@@ -78,5 +78,6 @@ public class ConversationStoreTest {
     Assert.assertEquals(expectedConversation.getTitle(), actualConversation.getTitle());
     Assert.assertEquals(
         expectedConversation.getCreationTime(), actualConversation.getCreationTime());
+    Assert.assertEquals(expectedConversation.isPrivate(), actualConversation.isPrivate());
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -3,6 +3,7 @@ package codeu.model.store.persistence;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.UserConversationMap;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import java.time.Instant;
@@ -36,40 +37,40 @@ public class PersistentDataStoreTest {
     appEngineTestHelper.tearDown();
   }
 
-  // @Test
-  // public void testSaveAndLoadUsers() throws PersistentDataStoreException {
-  //   UUID idOne = UUID.randomUUID();
-  //   String nameOne = "test_username_one";
-  //   String passwordOne = "password one";
-  //   Instant creationOne = Instant.ofEpochMilli(1000);
-  //   User inputUserOne = new User(idOne, nameOne, passwordOne, creationOne);
+  @Test
+  public void testSaveAndLoadUsers() throws PersistentDataStoreException {
+    UUID idOne = UUID.randomUUID();
+    String nameOne = "test_username_one";
+    String passwordOne = "password one";
+    Instant creationOne = Instant.ofEpochMilli(1000);
+    User inputUserOne = new User(idOne, nameOne, passwordOne, creationOne);
 
-  //   UUID idTwo = UUID.randomUUID();
-  //   String nameTwo = "test_username_two";
-  //   String passwordTwo = "password two";
-  //   Instant creationTwo = Instant.ofEpochMilli(2000);
-  //   User inputUserTwo = new User(idTwo, nameTwo, passwordTwo, creationTwo);
+    UUID idTwo = UUID.randomUUID();
+    String nameTwo = "test_username_two";
+    String passwordTwo = "password two";
+    Instant creationTwo = Instant.ofEpochMilli(2000);
+    User inputUserTwo = new User(idTwo, nameTwo, passwordTwo, creationTwo);
 
-  //   // save
-  //   persistentDataStore.writeThrough(inputUserOne);
-  //   persistentDataStore.writeThrough(inputUserTwo);
+    // save
+    persistentDataStore.writeThrough(inputUserOne);
+    persistentDataStore.writeThrough(inputUserTwo);
 
-  //   // load
-  //   List<User> resultUsers = persistentDataStore.loadUsers();
+    // load
+    List<User> resultUsers = persistentDataStore.loadUsers();
 
-  //   // confirm that what we saved matches what we loaded
-  //   User resultUserOne = resultUsers.get(0);
-  //   Assert.assertEquals(idOne, resultUserOne.getId());
-  //   Assert.assertEquals(nameOne, resultUserOne.getName());
-  //   Assert.assertEquals(passwordOne, resultUserOne.getPassword());
-  //   Assert.assertEquals(creationOne, resultUserOne.getCreationTime());
+    // confirm that what we saved matches what we loaded
+    User resultUserOne = resultUsers.get(0);
+    Assert.assertEquals(idOne, resultUserOne.getId());
+    Assert.assertEquals(nameOne, resultUserOne.getName());
+    Assert.assertEquals(passwordOne, resultUserOne.getPassword());
+    Assert.assertEquals(creationOne, resultUserOne.getCreationTime());
 
-  //   User resultUserTwo = resultUsers.get(1);
-  //   Assert.assertEquals(idTwo, resultUserTwo.getId());
-  //   Assert.assertEquals(nameTwo, resultUserTwo.getName());
-  //   Assert.assertEquals(passwordTwo, resultUserTwo.getPassword());
-  //   Assert.assertEquals(creationTwo, resultUserTwo.getCreationTime());
-  // }
+    User resultUserTwo = resultUsers.get(1);
+    Assert.assertEquals(idTwo, resultUserTwo.getId());
+    Assert.assertEquals(nameTwo, resultUserTwo.getName());
+    Assert.assertEquals(passwordTwo, resultUserTwo.getPassword());
+    Assert.assertEquals(creationTwo, resultUserTwo.getCreationTime());
+  }
 
   @Test
   public void testSaveAndLoadConversations() throws PersistentDataStoreException {
@@ -77,13 +78,15 @@ public class PersistentDataStoreTest {
     UUID ownerOne = UUID.randomUUID();
     String titleOne = "Test_Title";
     Instant creationOne = Instant.ofEpochMilli(1000);
-    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne);
+    boolean isPrivateOne = false;
+    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne, isPrivateOne);
 
     UUID idTwo = UUID.randomUUID();
     UUID ownerTwo = UUID.randomUUID();
     String titleTwo = "Test_Title_Two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
-    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo);
+    boolean isPrivateTwo = false;
+    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo, isPrivateTwo);
 
     // save
     persistentDataStore.writeThrough(inputConversationOne);
@@ -98,12 +101,57 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(ownerOne, resultConversationOne.getOwnerId());
     Assert.assertEquals(titleOne, resultConversationOne.getTitle());
     Assert.assertEquals(creationOne, resultConversationOne.getCreationTime());
+    Assert.assertEquals(isPrivateOne, resultConversationOne.isPrivate());
 
     Conversation resultConversationTwo = resultConversations.get(1);
     Assert.assertEquals(idTwo, resultConversationTwo.getId());
     Assert.assertEquals(ownerTwo, resultConversationTwo.getOwnerId());
     Assert.assertEquals(titleTwo, resultConversationTwo.getTitle());
     Assert.assertEquals(creationTwo, resultConversationTwo.getCreationTime());
+    Assert.assertEquals(isPrivateTwo, resultConversationTwo.isPrivate());
+  }
+
+  @Test
+  public void testSaveAndLoadPrivateConversations() throws PersistentDataStoreException {
+    UUID idOne = UUID.randomUUID();
+    UUID ownerOne = UUID.randomUUID();
+    String titleOne = "Test_Title";
+    Instant creationOne = Instant.ofEpochMilli(1000);
+    boolean isPrivateOne = true;
+    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne, isPrivateOne);
+    UserConversationMap mappingOne = new UserConversationMap(ownerOne, idOne);
+
+    UUID idTwo = UUID.randomUUID();
+    UUID ownerTwo = UUID.randomUUID();
+    String titleTwo = "Test_Title_Two";
+    Instant creationTwo = Instant.ofEpochMilli(2000);
+    boolean isPrivateTwo = true;
+    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo, isPrivateTwo);
+    UserConversationMap mappingTwo = new UserConversationMap(ownerTwo, idTwo);
+
+    // save
+    persistentDataStore.writeThrough(inputConversationOne);
+    persistentDataStore.writeThrough(inputConversationTwo);
+    persistentDataStore.writeThrough(mappingOne);
+    persistentDataStore.writeThrough(mappingTwo);
+
+    // load
+    Conversation resultConversationOne = persistentDataStore.loadPrivateConversations(ownerOne).get(0);
+    Conversation resultConversationTwo = persistentDataStore.loadPrivateConversations(ownerTwo).get(0);
+
+
+    // confirm that what we saved matches what we loaded
+    Assert.assertEquals(idOne, resultConversationOne.getId());
+    Assert.assertEquals(ownerOne, resultConversationOne.getOwnerId());
+    Assert.assertEquals(titleOne, resultConversationOne.getTitle());
+    Assert.assertEquals(creationOne, resultConversationOne.getCreationTime());
+    Assert.assertEquals(isPrivateOne, resultConversationOne.isPrivate());
+
+    Assert.assertEquals(idTwo, resultConversationTwo.getId());
+    Assert.assertEquals(ownerTwo, resultConversationTwo.getOwnerId());
+    Assert.assertEquals(titleTwo, resultConversationTwo.getTitle());
+    Assert.assertEquals(creationTwo, resultConversationTwo.getCreationTime());
+    Assert.assertEquals(isPrivateTwo, resultConversationTwo.isPrivate());
   }
 
   @Test

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -37,40 +37,40 @@ public class PersistentDataStoreTest {
     appEngineTestHelper.tearDown();
   }
 
-  @Test
-  public void testSaveAndLoadUsers() throws PersistentDataStoreException {
-    UUID idOne = UUID.randomUUID();
-    String nameOne = "test_username_one";
-    String passwordOne = "password one";
-    Instant creationOne = Instant.ofEpochMilli(1000);
-    User inputUserOne = new User(idOne, nameOne, passwordOne, creationOne);
+  // @Test
+  // public void testSaveAndLoadUsers() throws PersistentDataStoreException {
+  //   UUID idOne = UUID.randomUUID();
+  //   String nameOne = "test_username_one";
+  //   String passwordOne = "password one";
+  //   Instant creationOne = Instant.ofEpochMilli(1000);
+  //   User inputUserOne = new User(idOne, nameOne, passwordOne, creationOne);
 
-    UUID idTwo = UUID.randomUUID();
-    String nameTwo = "test_username_two";
-    String passwordTwo = "password two";
-    Instant creationTwo = Instant.ofEpochMilli(2000);
-    User inputUserTwo = new User(idTwo, nameTwo, passwordTwo, creationTwo);
+  //   UUID idTwo = UUID.randomUUID();
+  //   String nameTwo = "test_username_two";
+  //   String passwordTwo = "password two";
+  //   Instant creationTwo = Instant.ofEpochMilli(2000);
+  //   User inputUserTwo = new User(idTwo, nameTwo, passwordTwo, creationTwo);
 
-    // save
-    persistentDataStore.writeThrough(inputUserOne);
-    persistentDataStore.writeThrough(inputUserTwo);
+  //   // save
+  //   persistentDataStore.writeThrough(inputUserOne);
+  //   persistentDataStore.writeThrough(inputUserTwo);
 
-    // load
-    List<User> resultUsers = persistentDataStore.loadUsers();
+  //   // load
+  //   List<User> resultUsers = persistentDataStore.loadUsers();
 
-    // confirm that what we saved matches what we loaded
-    User resultUserOne = resultUsers.get(0);
-    Assert.assertEquals(idOne, resultUserOne.getId());
-    Assert.assertEquals(nameOne, resultUserOne.getName());
-    Assert.assertEquals(passwordOne, resultUserOne.getPassword());
-    Assert.assertEquals(creationOne, resultUserOne.getCreationTime());
+  //   // confirm that what we saved matches what we loaded
+  //   User resultUserOne = resultUsers.get(0);
+  //   Assert.assertEquals(idOne, resultUserOne.getId());
+  //   Assert.assertEquals(nameOne, resultUserOne.getName());
+  //   Assert.assertEquals(passwordOne, resultUserOne.getPassword());
+  //   Assert.assertEquals(creationOne, resultUserOne.getCreationTime());
 
-    User resultUserTwo = resultUsers.get(1);
-    Assert.assertEquals(idTwo, resultUserTwo.getId());
-    Assert.assertEquals(nameTwo, resultUserTwo.getName());
-    Assert.assertEquals(passwordTwo, resultUserTwo.getPassword());
-    Assert.assertEquals(creationTwo, resultUserTwo.getCreationTime());
-  }
+  //   User resultUserTwo = resultUsers.get(1);
+  //   Assert.assertEquals(idTwo, resultUserTwo.getId());
+  //   Assert.assertEquals(nameTwo, resultUserTwo.getName());
+  //   Assert.assertEquals(passwordTwo, resultUserTwo.getPassword());
+  //   Assert.assertEquals(creationTwo, resultUserTwo.getCreationTime());
+  // }
 
   @Test
   public void testSaveAndLoadConversations() throws PersistentDataStoreException {

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -3,6 +3,7 @@ package codeu.model.store.persistence;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.UserConversationMap;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.Before;
@@ -54,7 +55,7 @@ public class PersistentStorageAgentTest {
   @Test
   public void testWriteThroughConversation() {
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);
     persistentStorageAgent.writeThrough(conversation);
     Mockito.verify(mockPersistentDataStore).writeThrough(conversation);
   }
@@ -66,5 +67,14 @@ public class PersistentStorageAgentTest {
             UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "test content", Instant.now());
     persistentStorageAgent.writeThrough(message);
     Mockito.verify(mockPersistentDataStore).writeThrough(message);
+  }
+
+  @Test
+  public void testWriteThroughUserConversationMap() {
+    UserConversationMap mapping =
+        new UserConversationMap(
+            UUID.randomUUID(), UUID.randomUUID());
+    persistentStorageAgent.writeThrough(mapping);
+    Mockito.verify(mockPersistentDataStore).writeThrough(mapping);
   }
 }


### PR DESCRIPTION
I created a new object called UserConversationMap to store 1-to-1 map from a user id to a private conversation id. And then I added a boolean variable for Conversation object called isPrivate to indicate whether this conversation is private or public. Then for the PersistentDataStore, its loadConversations() method only loads public conversations now, and loadPrivateConversations can take in a userName or userID and return a list of private conversations associated with that user.